### PR TITLE
Work around a Swift bug

### DIFF
--- a/Sources/PrettierPrinter/Input.swift
+++ b/Sources/PrettierPrinter/Input.swift
@@ -1,0 +1,7 @@
+func readInput() -> String {
+    sequence(
+        first: readLine(strippingNewline: false) ?? "",
+        next: { _ in readLine(strippingNewline: false) }
+    )
+    .joined()
+}

--- a/Sources/PrettierPrinter/PrettierPrinter.swift
+++ b/Sources/PrettierPrinter/PrettierPrinter.swift
@@ -48,11 +48,3 @@ extension Indent: CustomStringConvertible {
         }
     }
 }
-
-private func readInput() -> String {
-    sequence(
-        first: readLine(strippingNewline: false) ?? "",
-        next: { _ in readLine(strippingNewline: false) }
-    )
-    .joined()
-}


### PR DESCRIPTION
Move top level function out of PrettierPrinter.swift (the file with
@main) to work around SR-12683: https://bugs.swift.org/browse/SR-12683