### PR TITLE
Fix handling of escaped single quote

### DIFF
--- a/Sources/PrettierPrinterCore/Instructions.swift
+++ b/Sources/PrettierPrinterCore/Instructions.swift
@@ -28,14 +28,7 @@ let closeBracketParser = groupCloseParser("]")
 
 let commaParser = PrettierPrinterParser.literal(",").map(instr(.insert(","), .newline))
 
-// Handle double-quoted strings with escaped quotes inside them. Also recognize other escaped
-// characters.
-let escapables = #"\"0nrtvfb"#.map { c -> Parser<String> in
-    let s = String(c)
-    return literal(s).map(const(s))
-}
-
-let escaped = zip(literal("\\"), oneOf(escapables)).map { #"\\#($0.1)"# }
+let escaped = zip(literal("\\"), char).map { #"\\#($0.1)"# }
 let notQuote = prefix(while: { $0 != "\"" && $0 != "\\" }).filter { !$0.isEmpty }.map(String.init)
 let stringPart = oneOf([escaped, notQuote])
 let stringContent = oneOrMore(stringPart, separatedBy: always(())).map { $0.joined() }

--- a/Tests/PrettierPrinterTests/ParserTests.swift
+++ b/Tests/PrettierPrinterTests/ParserTests.swift
@@ -20,6 +20,12 @@ final class PrettierPrinterTests: XCTestCase {
         XCTAssertEqual([.insert("abc "), .insert(#""z\na\"p""#), .insert(" pop")], instructions)
     }
 
+    func testEscapedSingleQuote() throws {
+        let (instructions, rest) = PrettierPrinterCore.instructionsParser.run(#"abc "don\'t do it" pop"#)
+        XCTAssertEqual(rest, "")
+        XCTAssertEqual([.insert("abc "), .insert(#""don\'t do it""#), .insert(" pop")], instructions)
+    }
+
     func testParensInQuotes() throws {
         let (instructions, rest) = PrettierPrinterCore.instructionsParser.run(#"abc "Olp(neep)" pop"#)
         XCTAssertEqual(rest, "")


### PR DESCRIPTION
Having an escaped single quote inside a string (i.e. "don\'t do it")
would break the formatting. Now prpr doesn't care what you are
escaping, anything preceded by a backslash is handled correctly.
